### PR TITLE
fix: let nuxt module import tailwind reset css

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -6,6 +6,5 @@
 </template>
 
 <style>
-@import '@unocss/reset/tailwind.css';
 @import '~/styles/main.css';
 </style>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -13,6 +13,7 @@ export default defineNuxtConfig({
     ],
     uno: true,
     attributify: true,
+    preflight: true,
     icons: {
       scale: 1.2,
     },


### PR DESCRIPTION
I noticed that the reset.css from tailwind is importet after uno.css. This overwrites e.g. button background colors. I think using the preflight option from nuxt plugin solves this issue.