### PR TITLE
chore: `buildModules` is deprecated

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -9,7 +9,7 @@ export default defineNuxtConfig({
       },
     ],
   },
-  buildModules: [
+  modules: [
     '@vueuse/nuxt',
     '@unocss/nuxt',
     '@pinia/nuxt',


### PR DESCRIPTION
Just use `modules` now. Reference: https://github.com/nuxt/framework/pull/3830