### PR TITLE
fix: color mode preference.

### DIFF
--- a/components/DarkToggle.vue
+++ b/components/DarkToggle.vue
@@ -1,7 +1,7 @@
 <script setup lang='ts'>
 const color = useColorMode()
 function toggleDark() {
-  color.preference = color.preference === 'dark' ? 'light' : 'dark'
+  color.preference = color.value === 'dark' ? 'light' : 'dark'
 }
 </script>
 


### PR DESCRIPTION
preference is `system` by default. so checking if it's `dark` is cause an issue where you have to click it twice. the solution is comparing it with `color.value`, which has actual color, and set `color.preference` in terms of the result.

PS: `color.value` updating automatically after calling toggleDark function so we don't have to set it too.