### PR TITLE
chore:layout typo

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -10,7 +10,7 @@ useHead({
 </script>
 
 <template>
-  <NuxtLayout cl>
+  <NuxtLayout>
     <NuxtPage />
   </NuxtLayout>
 </template>


### PR DESCRIPTION
### Description

Found a `cl` on the `<NuxtLayout>` component on the `app.vue` file. After some research found an issue #54 that confirmed that this is just a typo.
fix #54

### Linked Issues

https://github.com/antfu/vitesse-nuxt3/issues/54